### PR TITLE
Set lineComment symbol to "#" and remove blockComment

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,9 +1,9 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
+        "lineComment": "#"
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        //"blockComment": [ "/*", "*/" ]
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
CFEngine only supports single line comments, and these are with "#"
instead of "//".